### PR TITLE
Check that GPG keys actually exist on a public keyserver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ addons:
   apt:
     packages:
       - python3
+      - python3-gnupg
 script: ./tests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
-addons:
-  apt:
-    packages:
-      - python3
-      - python3-gnupg
+python:
+  - "3.4"
+language: python
+install: "pip install gnupg"
 script: ./tests.py

--- a/tests.py
+++ b/tests.py
@@ -39,8 +39,8 @@ def validate(path):
                 for server in GPG_SERVERS:
                     gpg_result = gpg.recv_keys(server, peers[host]['gpg'])
                     print("    %s%s key(s) found on %s when searching for %s%s" %
-                         (YELLOW, gpg_result.count, server, peers[host]['gpg'], END))
-                    if gpg_result.count > 0:
+                         (YELLOW, len(gpg_result.results), server, peers[host]['gpg'], END))
+                    if len(gpg_result.results) > 0:
                         is_on_keyserver = True
                 if not is_on_keyserver:
                     print("    %s%s not found on any keyserver%s" %


### PR DESCRIPTION
Currently checks `pgp.mit.edu` and `keys.gnupg.net`, but that's easily changable at the top of the tests.