### PR TITLE
Deleting my Singapore Node

### DIFF
--- a/AS/sg/singapore/weuxel.sing.k
+++ b/AS/sg/singapore/weuxel.sing.k
@@ -1,8 +1,0 @@
-{
-    "128.199.246.213:64022":{
-        "contact":"hype@smash-net.org",
-        "password":"public_access",
-        "publicKey":"ff3yru5mxjf13c4kpw1nys4j6pz9q191cds85srmsnxnql47q5p0.k",
-        "user":"weuxel"
-    }
-}


### PR DESCRIPTION
This node will continue to work but using it as a new peer is discouraged.